### PR TITLE
Do not assign new fp attribute to image when closing

### DIFF
--- a/Tests/test_image.py
+++ b/Tests/test_image.py
@@ -1027,7 +1027,6 @@ class TestImage:
 
             assert len(self._caplog.records) == 0
             assert im.fp is None
-            assert copy.fp is None
 
 
 class MockEncoder:

--- a/Tests/test_image.py
+++ b/Tests/test_image.py
@@ -1,4 +1,5 @@
 import io
+import logging
 import os
 import shutil
 import sys
@@ -1014,18 +1015,13 @@ class TestImage:
             except OSError as e:
                 assert str(e) == "buffer overrun when reading image file"
 
-    @pytest.fixture(scope="function")
-    def inject_caplog(self, caplog):
-        self._caplog = caplog
-
-    @pytest.mark.usefixtures("inject_caplog")
-    def test_close_graceful(self):
+    def test_close_graceful(self, caplog):
         with Image.open("Tests/images/hopper.jpg") as im:
             copy = im.copy()
-            im.close()
-            copy.close()
-
-            assert len(self._caplog.records) == 0
+            with caplog.at_level(logging.DEBUG):
+                im.close()
+                copy.close()
+            assert len(caplog.records) == 0
             assert im.fp is None
 
 

--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -549,17 +549,17 @@ class Image:
         :py:meth:`~PIL.Image.Image.load` method. See :ref:`file-handling` for
         more information.
         """
-        try:
-            if hasattr(self, "fp"):
+        if hasattr(self, "fp"):
+            try:
                 if getattr(self, "_fp", False):
                     if self._fp != self.fp:
                         self._fp.close()
                     self._fp = DeferredError(ValueError("Operation on closed image"))
                 if self.fp:
                     self.fp.close()
-            self.fp = None
-        except Exception as msg:
-            logger.debug("Error closing: %s", msg)
+                self.fp = None
+            except Exception as msg:
+                logger.debug("Error closing: %s", msg)
 
         if getattr(self, "map", None):
             self.map = None


### PR DESCRIPTION
Suggestions for https://github.com/python-pillow/Pillow/pull/7557

- `hasattr(self, "fp")` shouldn't raise an exception, so I've moved it out of the `try` block. This also has the effect of not assigning `fp = None` on images that didn't have an `fp` before.
- Testing, I found that your logging test didn't fail when I removed the source code change. I've instead mirrored https://github.com/python-pillow/Pillow/blob/28c173f8d4767c7f6dd22dc840117fe641f4d3ee/Tests/test_image_load.py#L27-L32, and that does detect debug messages correctly.